### PR TITLE
Replace xmldom with @xmldom/xmldom 0.8.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,23 @@
       "name": "@tfso/njs-xml",
       "version": "1.5.1.dintero",
       "dependencies": {
+        "@xmldom/xmldom": "0.8.10",
         "lodash": "^4.17.15",
         "sax": "^1.2.4",
         "through2": "^2.0.5",
-        "xml2js": "^0.5.0",
-        "xmldom": "^0.6.0"
+        "xml2js": "^0.5.0"
       },
       "devDependencies": {
         "chai": "^4.2.0",
         "mocha": "10.2.0"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -1005,14 +1013,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -1086,6 +1086,11 @@
     }
   },
   "dependencies": {
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+    },
     "ansi-colors": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
@@ -1817,11 +1822,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
-    },
-    "xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "sax": "^1.2.4",
     "through2": "^2.0.5",
     "xml2js": "^0.5.0",
-    "xmldom": "^0.6.0"
+    "@xmldom/xmldom": "0.8.10"
   },
   "devDependencies": {
     "chai": "^4.2.0",

--- a/src/XmlWriter.js
+++ b/src/XmlWriter.js
@@ -1,6 +1,6 @@
-const DOMImplementation = require('xmldom').DOMImplementation
-const XMLSerializer = require('xmldom').XMLSerializer
-const DOMParser = require('xmldom').DOMParser
+const DOMImplementation = require('@xmldom/xmldom').DOMImplementation
+const XMLSerializer = require('@xmldom/xmldom').XMLSerializer
+const DOMParser = require('@xmldom/xmldom').DOMParser
 const XmlReader = require('./XmlReader')
 
 class XmlWriter{


### PR DESCRIPTION
> Since version 0.7.0 this package is published to npm as @xmldom/xmldom
> and no longer as xmldom, because we are no longer able to publish
> xmldom.

Replace the dependency to fix `CVE-2022-39299` and `CVE-2021-32796`

Rel: https://nvd.nist.gov/vuln/detail/CVE-2022-39299
