### PR TITLE
Remove `chai` dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
                 "xml2js": "^0.6.2"
             },
             "devDependencies": {
-                "chai": "^4.3.10",
                 "mocha": "^10.3.0",
                 "prettier": "^3.1.1"
             },
@@ -83,15 +82,6 @@
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
         },
-        "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-            "dev": true,
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -146,24 +136,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/chai": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-            "dev": true,
-            "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -190,18 +162,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-            "dev": true,
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chokidar": {
@@ -295,18 +255,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/deep-eql": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-            "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-            "dev": true,
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/diff": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -393,15 +341,6 @@
             "dev": true,
             "engines": {
                 "node": "6.* || 8.* || >= 10.*"
-            }
-        },
-        "node_modules/get-func-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-            "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/glob": {
@@ -588,15 +527,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/loupe": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
-            "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
-            "dev": true,
-            "dependencies": {
-                "get-func-name": "^2.0.0"
-            }
-        },
         "node_modules/minimatch": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
@@ -705,15 +635,6 @@
             "dev": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-            "dev": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/picomatch": {
@@ -898,15 +819,6 @@
             },
             "engines": {
                 "node": ">=8.0"
-            }
-        },
-        "node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
             }
         },
         "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
         "xml2js": "^0.6.2"
     },
     "devDependencies": {
-        "chai": "^4.3.10",
         "mocha": "^10.3.0",
         "prettier": "^3.1.1"
     }

--- a/test/streamParse.test.js
+++ b/test/streamParse.test.js
@@ -4,7 +4,7 @@ const streamParse = require('../src/streamParse')
 const through2 = require('through2')
 const fs = require('fs')
 const path = require('path')
-const chai = require('chai')
+const assert = require('node:assert')
 
 describe('streamParse', () => {
     it('should read sample.xml the same way as parse', async () => {
@@ -29,10 +29,10 @@ describe('streamParse', () => {
         })
 
         const output = await p
-        chai.expect(output.length).to.equal(1)
+        assert.strictEqual(output.length, 1)
         const data = output[0]
 
-        chai.expect(data).to.deep.equal(expectedData)
+        assert.deepEqual(data, expectedData)
     })
 
     it('should read sample2.xml the same way as parse', async () => {
@@ -57,10 +57,10 @@ describe('streamParse', () => {
         })
 
         const output = await p
-        chai.expect(output.length).to.equal(1)
+        assert.strictEqual(output.length, 1)
         const data = output[0]
 
-        chai.expect(data).to.deep.equal(expectedData)
+        assert.deepEqual(data, expectedData)
     })
 
     it('should throw error if bad xml', async () => {
@@ -81,7 +81,7 @@ describe('streamParse', () => {
         let error = null
         await p.catch((err) => (error = err))
 
-        chai.expect(error).to.not.equal(null)
-        chai.expect(error.message).to.contain('Invalid attribute')
+        assert.strictEqual(error !== null, true)
+        assert.strictEqual(error.message.includes('Invalid attribute'), true)
     })
 })

--- a/test/xmlReader.test.js
+++ b/test/xmlReader.test.js
@@ -2,7 +2,7 @@ const XmlReader = require('../src/XmlReader')
 const through2 = require('through2')
 const fs = require('fs')
 const path = require('path')
-const chai = require('chai')
+const assert = require('node:assert')
 
 async function parseWithStream(data, splitOn) {
     return new Promise((resolve, reject) => {
@@ -53,7 +53,7 @@ describe('XmlReader', () => {
 
         const readerAgain = (await parseWithStream(xmlStr))[0]
 
-        chai.expect(reader.data).to.deep.equal(readerAgain.data)
+        assert.deepEqual(reader.data, readerAgain.data)
     })
 
     it('should read+write+read sample file using xml2js and give the same result', async () => {
@@ -68,62 +68,65 @@ describe('XmlReader', () => {
 
         const readerAgain = await XmlReader.parse(xmlStr)
 
-        chai.expect(reader.data).to.deep.equal(readerAgain.data)
+        assert.deepEqual(reader.data, readerAgain.data)
     })
 
     it('should read some basic things', async () => {
         const reader = await XmlReader.parse(testData1)
 
-        chai.expect(reader.attributeAt('test', 'hello')).to.equal('world')
+        assert.deepEqual(reader.attributeAt('test', 'hello'), 'world')
 
-        chai.expect(reader.valAt('list.item.nestedlist.nesteditem')).to.equal(
-            '1'
+        assert.deepEqual(reader.valAt('list.item.nestedlist.nesteditem'), '1')
+
+        assert.strictEqual(reader.has('list'), true)
+
+        assert.strictEqual(reader.has('blarg'), false)
+
+        assert.deepEqual(
+            reader
+                .asArray('list.item.nestedlist.nesteditem')
+                .map((r) => r.val()),
+            ['1', '2']
         )
 
-        chai.expect(reader.has('list')).to.equal(true)
-
-        chai.expect(reader.has('blarg')).to.equal(false)
-
-        chai.expect(
+        assert.deepEqual(
             reader
                 .asArray('list.item.nestedlist.nesteditem')
-                .map((r) => r.val())
-        ).to.deep.equal(['1', '2'])
+                .map((r) => r.attribute('attr')),
+            ['attr1', 'attr2']
+        )
 
-        chai.expect(
-            reader
-                .asArray('list.item.nestedlist.nesteditem')
-                .map((r) => r.attribute('attr'))
-        ).to.deep.equal(['attr1', 'attr2'])
-
-        chai.expect(
+        assert.deepEqual(
             reader
                 .asArrayAll('list.item.nestedlist.nesteditem')
-                .map((r) => r.val())
-        ).to.deep.equal(['1', '2', '3', '4'])
+                .map((r) => r.val()),
+            ['1', '2', '3', '4']
+        )
     })
 
     it('should parse some basic stuff by stream', async () => {
         const readers = await parseWithStream(testData1, 'list.item')
 
-        chai.expect(readers[0].valAt('test')).to.equal('yo')
+        assert.strictEqual(readers[0].valAt('test'), 'yo')
 
-        chai.expect(readers[0].valAt('list.otheritem')).to.equal('yoyo')
+        assert.strictEqual(readers[0].valAt('list.otheritem'), 'yoyo')
 
-        chai.expect(
+        assert.deepEqual(
             readers[0]
                 .asArrayAll('list.item.nestedlist.nesteditem')
-                .map((r) => r.val())
-        ).to.deep.equal(['1', '2'])
+                .map((r) => r.val()),
+            ['1', '2']
+        )
 
-        chai.expect(readers[1].valAt('test')).to.equal('yo')
+        assert.strictEqual(readers[1].valAt('test'), 'yo')
 
-        chai.expect(readers[1].valAt('list.otheritem')).to.equal('yoyo')
+        assert.strictEqual(readers[1].valAt('list.otheritem'), 'yoyo')
 
-        chai.expect(
+        assert.deepEqual(
             readers[1]
                 .asArrayAll('list.item.nestedlist.nesteditem')
-                .map((r) => r.val())
-        ).to.deep.equal(['3', '4'])
+                .map((r) => r.val()),
+            ['3', '4']
+        )
     })
 })

--- a/test/xmlWriter.test.js
+++ b/test/xmlWriter.test.js
@@ -1,6 +1,6 @@
 const XmlReader = require('../src/XmlReader')
 const XmlWriter = require('../src/XmlWriter')
-const chai = require('chai')
+const assert = require('node:assert')
 
 const testData1 = `
 <document>
@@ -33,7 +33,7 @@ describe('XmlWriter', () => {
 
         const finalReader = await XmlReader.parse(writer.toFragmentString())
 
-        chai.expect(finalReader.valAt('nestedlist.nesteditem')).to.equal('1')
+        assert.strictEqual(finalReader.valAt('nestedlist.nesteditem'), '1')
     })
 
     it('should set a raw value', async () => {
@@ -45,7 +45,7 @@ describe('XmlWriter', () => {
 
         const reader = await XmlReader.parse(writer.toString())
 
-        chai.expect(reader.valAt('test')).to.equal('hello!')
+        assert.strictEqual(reader.valAt('test'), 'hello!')
     })
 
     it('should inject several simple values', async () => {
@@ -53,7 +53,8 @@ describe('XmlWriter', () => {
 
         writer.adds('node', ['a', 'b'])
 
-        chai.expect(writer.toString()).to.deep.equal(
+        assert.deepEqual(
+            writer.toString(),
             '<?xml version="1.0" encoding="utf-8"?><Document><node>a</node><node>b</node></Document>'
         )
     })
@@ -66,7 +67,8 @@ describe('XmlWriter', () => {
             prop: 'yo',
         })
 
-        chai.expect(writer.toString()).to.deep.equal(
+        assert.deepEqual(
+            writer.toString(),
             '<?xml version="1.0" encoding="utf-8"?><Document><node prop="yo"><id>a</id></node><node prop="yo"><id>b</id></node></Document>'
         )
     })


### PR DESCRIPTION
There is no plan to convert this module to ESM

Rel: https://github.com/chaijs/chai/issues/1561
Rel: https://github.com/Dintero/njs-tfso-xml/pull/13
